### PR TITLE
Should actually announce-port properly

### DIFF
--- a/templates/default/sentinel.conf.erb
+++ b/templates/default/sentinel.conf.erb
@@ -38,7 +38,7 @@ port <%=@sentinel_port%>
 #
 # sentinel announce-ip 1.2.3.4
 <%= "sentinel announce-ip #{@announce_ip}" unless @announce_ip.nil? %>
-<%= "sentinel announce-ip #{@announce_port}" unless @announce_port.nil? %>
+<%= "sentinel announce-port #{@announce_port}" unless @announce_port.nil? %>
 
 # sentinel monitor <master-name> <ip> <redis-port> <quorum>
 #


### PR DESCRIPTION
Was testing creating a new sentinel when we define `announce-ip` and `announce-port`, I found in the config file that `announce-ip` would always equal the port and there would be no `announce-port` config:

```
# in sentinel.conf
sentinel announce-ip "26379"
```

Had a look in here and saw that there is a typo causing `announce-ip` to be overwritten to the port